### PR TITLE
fix: use base laravel Str class

### DIFF
--- a/src/QuickBooksAuthenticator.php
+++ b/src/QuickBooksAuthenticator.php
@@ -23,7 +23,7 @@ class QuickBooksAuthenticator
     public static function getAuthorizationUrl(): string
     {
         $cookieLife  = 30;
-        $cookieValue = str_random(32);
+        $cookieValue = \Str::random(32);
         $validUntil  = Carbon::now()->addMinutes($cookieLife)->timestamp;
         Cookie::queue(Cookie::make('quickbooks_auth', $cookieValue, $cookieLife));
         cache(['qb-auth-cookie' => "{$cookieValue}|{$validUntil}"], $cookieLife);


### PR DESCRIPTION
str_* helper functions have been removed for a while, and should not be relied on.