### PR TITLE
chore: bump illuminate/support dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/JarvusInnovations/laravel-quickbooks",
     "keywords": ["Laravel", "laravel-quickbooks"],
     "require": {
-        "illuminate/support": "~9|~8|~7|^6.2|~5",
+        "illuminate/support": "~11|~10|~9|~8|~7|^6.2|~5",
         "quickbooks/v3-php-sdk": "^6.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
- add support for illuminate/support `~11` & `~10`